### PR TITLE
Allow $pdo to be nullable, to be able to extend class yourself + adjust VARCHAR into TEXT

### DIFF
--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -58,12 +58,6 @@ class MySQLHandler extends AbstractProcessingHandler {
     	if(!is_null($pdo)) {
         	$this->pdo = $pdo;
         }
-        if(!is_null($additionalFields)) {
-        	$this->additionalFields = $additionalFields;
-        }
-        if(!is_null($table)) {
-        	$this->table = $table;
-        }
         parent::__construct($level, $bubble);
     }
 

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -54,10 +54,16 @@ class MySQLHandler extends AbstractProcessingHandler {
      * @param bool|int $level           Debug level which this handler should store
      * @param bool $bubble
      */
-    public function __construct(PDO $pdo, $table, $additionalFields = array(), $level = Logger::DEBUG, $bubble = true) {
-        $this->pdo = $pdo;
-        $this->additionalFields = $additionalFields;
-        $this->table = $table;
+    public function __construct(PDO $pdo = null, $table = null, $additionalFields = array(), $level = Logger::DEBUG, $bubble = true) {
+    	if(!is_null($pdo)) {
+        	$this->pdo = $pdo;
+        }
+        if(!is_null($additionalFields)) {
+        	$this->additionalFields = $additionalFields;
+        }
+        if(!is_null($table)) {
+        	$this->table = $table;
+        }
         parent::__construct($level, $bubble);
     }
 

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -24,7 +24,7 @@ class MySQLHandler extends AbstractProcessingHandler {
     /**
      * @var PDO pdo object of database connection
      */
-    private $pdo;
+    protected $pdo;
 
     /**
      * @var PDOStatement statement to insert a new record
@@ -34,7 +34,7 @@ class MySQLHandler extends AbstractProcessingHandler {
     /**
      * @var string the table to store the logs in
      */
-    private $table = 'logs';
+    protected $table = 'logs';
 
     /**
      * @var string[] additional fields to be stored in the database
@@ -43,7 +43,7 @@ class MySQLHandler extends AbstractProcessingHandler {
      * is expected along the message, and further the database needs to have these fields
      * as the values are stored in the column name $field.
      */
-    private $additionalFields = array();
+    protected $additionalFields = array();
 
     /**
      * Constructor of this class, sets the PDO and calls parent constructor

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -54,10 +54,12 @@ class MySQLHandler extends AbstractProcessingHandler {
      * @param bool|int $level           Debug level which this handler should store
      * @param bool $bubble
      */
-    public function __construct(PDO $pdo = null, $table = null, $additionalFields = array(), $level = Logger::DEBUG, $bubble = true) {
+    public function __construct(PDO $pdo = null, $table, $additionalFields = array(), $level = Logger::DEBUG, $bubble = true) {
     	if(!is_null($pdo)) {
         	$this->pdo = $pdo;
         }
+        $this->table = $table;
+        $this->additionalFields = $additionalFields;
         parent::__construct($level, $bubble);
     }
 

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -34,7 +34,7 @@ class MySQLHandler extends AbstractProcessingHandler {
     /**
      * @var string the table to store the logs in
      */
-    protected $table = 'logs';
+    private $table = 'logs';
 
     /**
      * @var string[] additional fields to be stored in the database
@@ -43,7 +43,7 @@ class MySQLHandler extends AbstractProcessingHandler {
      * is expected along the message, and further the database needs to have these fields
      * as the values are stored in the column name $field.
      */
-    protected $additionalFields = array();
+    private $additionalFields = array();
 
     /**
      * Constructor of this class, sets the PDO and calls parent constructor

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -91,7 +91,7 @@ class MySQLHandler extends AbstractProcessingHandler {
 
         //Add columns
         if (!empty($addedColumns)) foreach ($addedColumns as $c) {
-            $this->pdo->exec('ALTER TABLE `'.$this->table.'` add `'.$c.'` VARCHAR(200) NULL DEFAULT NULL;');
+            $this->pdo->exec('ALTER TABLE `'.$this->table.'` add `'.$c.'` TEXT NULL DEFAULT NULL;');
         }
 
         //Prepare statement


### PR DESCRIPTION
I changed $pdo into a nullable parameter. Allows me to extend your class and add my own PDO class into the object. Point is that I use a PDO connection, but it's wrapped in another object for debugging purposes (PHPDebugBar). 

Besides that I adjusted the VARCHAR(200) into TEXT. In some cases more logging is required. Data storage required is length + 2 bytes, so still people can insert short data without big problems. 