### PR TITLE
add 'id' to the default fields

### DIFF
--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -40,7 +40,7 @@ class MySQLHandler extends AbstractProcessingHandler
     /**
      * @var array default fields that are stored in db
      */
-    private $defaultfields = array('channel', 'level', 'message', 'time');
+    private $defaultfields = array('id', 'channel', 'level', 'message', 'time');
 
     /**
      * @var string[] additional fields to be stored in the database


### PR DESCRIPTION
Hello,

As the table is now initialized with a primary key, the 'id' column should be part of the default fields. Otherwise, it's removed  around line 110 after the diff.

Regards
Mikael