### PR TITLE
Fix for SQLSTATE[HY093]: Invalid parameter number

### DIFF
--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -205,6 +205,13 @@ class MySQLHandler extends AbstractProcessingHandler
 
         $this->prepareStatement();
 
+	    //Remove unused keys
+	    foreach($this->additionalFields as $key => $context) {
+		    if(! isset($contentArray[$key])) {
+			    unset($this->additionalFields[$key]);
+		    }
+	    }
+
         //Fill content array with "null" values if not provided
         $contentArray = $contentArray + array_combine(
             $this->additionalFields,


### PR DESCRIPTION
Fixes issue mentioned here https://github.com/waza-ari/monolog-mysql/issues/23

“Situation:

When some additionalFields are provided with empty values.
No logs are recorded to database when this warning shows.

Code problem observed:

While $contentArray contains the full list of key-values,
$this->statement is only prepared with keys that has non-empty values. Thus it is true that number of bound variables does not match number of tokens.”