### PR TITLE
Removed unsetting of null values of $contentArray

### DIFF
--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -210,7 +210,6 @@ class MySQLHandler extends AbstractProcessingHandler
         foreach($contentArray as $key => $context) {
             if (! in_array($key, $this->fields)) {
                 unset($contentArray[$key]);
-                unset($this->fields[array_search($key, $this->fields)]);
                 continue;
             }
         }

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -208,7 +208,7 @@ class MySQLHandler extends AbstractProcessingHandler
 
         // unset array keys that are passed put not defined to be stored, to prevent sql errors
         foreach($contentArray as $key => $context) {
-            if (! in_array($key, $this->fields)) {
+            if (! in_array($key, $this->fields, true)) {
                 unset($contentArray[$key]);
                 continue;
             }


### PR DESCRIPTION
Because however later they are added again with array_combine().

test.php file:

```
<?php

use MySQLHandler\MySQLHandler;

require __DIR__ . '/vendor/autoload.php';

putenv('DB_HOST=localhost');
putenv('DB_NAME=database');
putenv('DB_USER=user');
putenv('DB_PASS=password');

$conn = new PDO('mysql:host='.getenv('DB_HOST').';dbname='.getenv('DB_NAME'), getenv('DB_USER'), getenv('DB_PASS'));

$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

$mySQLHandler = new MySQLHandler($conn, 'log', ['username', 'userid'], \Monolog\Logger::DEBUG);

$logger = new \Monolog\Logger( 'debug' );
$logger->pushHandler( $mySQLHandler );

$logger->addWarning('This is a great message, woohoo!', ['username'  => 'John Doe', 'userid'  => null]);
```

Command:

> $ php -f test.php

Output:

> PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in .../monolog-mysql/vendor/wazaari/monolog-mysql/src/MySQLHandler/MySQLHandler.php:214





