### PR TITLE
Partially fix transaction autocommit and fix compatibility fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ MySQL Handler for Monolog, which allows to store log messages in a MySQL Table.
 It can log text messages to a specific table, and creates the table automatically if it does not exist.
 The class further allows to dynamically add extra attributes, which are stored in a separate database field, and can be used for later analyzing and sorting.
 
-Homepage: http://www.d-herrmann.de/projects/monolog-mysql-handler/
-
 # HELP WANTED
 
-As I do not use this project myself anymore and I do not find the time to maintain this project as it deserves I would be happy to find someone taking it over. Please contact me at danielherrmann+gitlab@postep.de if you'd be interesting to take over that project. Thanks!
+As I do not use this project myself anymore and I do not find the time to maintain this project as it deserves I would be happy to find someone taking it over. Please contact me at danielherrmann+gitlab@posteo.de if you'd be interesting to take over that project. Thanks!
 
 # Installation
 monolog-mysql is available via composer. Just add the following line to your required section in composer.json and do a `php composer.phar update`.

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -161,7 +161,7 @@ class MySQLHandler extends AbstractProcessingHandler
      * @param  $record[]
      * @return void
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         if (!$this->initialized) {
             $this->initialize();

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -238,6 +238,11 @@ class MySQLHandler extends AbstractProcessingHandler
             }
         }
 
+        // remove default fields which are not provided in $contentArray; we can skip 'id' too, because it is PRIMARY AI key
+        $this->fields = array_filter($this->fields, static function($val) use ($contentArray) {
+            return array_key_exists($val, $contentArray);
+        });
+
         $this->prepareStatement();
 
         //Remove unused keys

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -242,7 +242,7 @@ class MySQLHandler extends AbstractProcessingHandler
 
         //Remove unused keys
         foreach ($this->additionalFields as $key => $context) {
-            if (isset($contentArray[$key])) {
+            if (isset($contentArray[$context])) {
                 unset($this->additionalFields[$key]);
             }
         }

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -241,8 +241,8 @@ class MySQLHandler extends AbstractProcessingHandler
         $this->prepareStatement();
 
         //Remove unused keys
-        foreach ($this->additionalFields as $key => $context) {
-            if (isset($contentArray[$key])) {
+        foreach($this->additionalFields as $key => $context) {
+            if(! isset($contentArray[$key])) {
                 unset($this->additionalFields[$key]);
             }
         }

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -242,7 +242,7 @@ class MySQLHandler extends AbstractProcessingHandler
 
         //Remove unused keys
         foreach ($this->additionalFields as $key => $context) {
-            if (isset($contentArray[$context])) {
+            if (isset($contentArray[$key])) {
                 unset($this->additionalFields[$key]);
             }
         }

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -241,8 +241,8 @@ class MySQLHandler extends AbstractProcessingHandler
         $this->prepareStatement();
 
         //Remove unused keys
-        foreach($this->additionalFields as $key => $context) {
-            if(! isset($contentArray[$key])) {
+        foreach ($this->additionalFields as $key => $context) {
+            if (isset($contentArray[$key])) {
                 unset($this->additionalFields[$key]);
             }
         }


### PR DESCRIPTION
1.
> Some databases, including MySQL, automatically issue an implicit COMMIT when a database definition language (DDL) statement such as DROP TABLE or CREATE TABLE is issued within a transaction. The implicit COMMIT will prevent you from rolling back any other changes within the transaction boundary. 

Source: https://www.php.net/manual/en/pdo.begintransaction.php

I've created a new method which checks if logs table exists, called in most cases only once. If the table exists, query `CREATE TABLE...` isn't called preventing transaction autocommit.

Todo: solution to prevent autocommit if table doesn't exist - first call of method createLogsTable() (when the table doesn't exist) still breaks transaction. See #25 

2. Fix for: `Fatal error: Declaration of MySQLHandler\MySQLHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void in [...]\vendor\wazaari\monolog-mysql\src\MySQLHandler\MySQLHandler.php on line 164`