### PR TITLE
Allow skipping attempts to modify database

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Just use it as any other Monolog Handler, push it to the stack of your Monolog L
 - **$bubble** _Defaults to true_
 - **$skipDatabaseModifications** Defines whether we should skip any attempts to sync current database state with what's requested by the code (includes creating the table and adding / dropping fields). _Defaults to false_
 
+If $skipDatabaseModifications is set to true, please use the following query as a template to create the log table (with additional fields, if necessary)
+```mysql
+CREATE TABLE `log` (
+    id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, channel VARCHAR(255), level INTEGER, message LONGTEXT, time INTEGER UNSIGNED, INDEX(channel) USING HASH, INDEX(level) USING HASH, INDEX(time) USING BTREE
+)
+```
+
 # Examples
 Given that $pdo is your database instance, you could use the class as follows:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Just use it as any other Monolog Handler, push it to the stack of your Monolog L
 - **$additionalFields** simple array of additional database fields, which should be stored in the database. The columns are created automatically, and the fields can later be used in the extra context section of a record. See examples below. _Defaults to an empty array()_
 - **$level** can be any of the standard Monolog logging levels. Use Monologs statically defined contexts. _Defaults to Logger::DEBUG_
 - **$bubble** _Defaults to true_
+- **$skipDatabaseModifications** Defines whether we should skip any attempts to sync current database state with what's requested by the code (includes creating the table and adding / dropping fields). _Defaults to false_
 
 # Examples
 Given that $pdo is your database instance, you could use the class as follows:

--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -60,18 +60,20 @@ class MySQLHandler extends AbstractProcessingHandler
     /**
      * Constructor of this class, sets the PDO and calls parent constructor
      *
-     * @param PDO $pdo                  PDO Connector for the database
-     * @param bool $table               Table in the database to store the logs in
-     * @param array $additionalFields   Additional Context Parameters to store in database
-     * @param bool|int $level           Debug level which this handler should store
-     * @param bool $bubble
+     * @param PDO      $pdo                       PDO Connector for the database
+     * @param bool     $table                     Table in the database to store the logs in
+     * @param array    $additionalFields          Additional Context Parameters to store in database
+     * @param bool|int $level                     Debug level which this handler should store
+     * @param bool     $bubble
+     * @param bool     $skipDatabaseModifications Defines whether attempts to alter database should be skipped
      */
     public function __construct(
         PDO $pdo = null,
         $table,
         $additionalFields = array(),
         $level = Logger::DEBUG,
-        $bubble = true
+        $bubble = true,
+        $skipDatabaseModifications = false
     ) {
        if (!is_null($pdo)) {
             $this->pdo = $pdo;
@@ -79,6 +81,11 @@ class MySQLHandler extends AbstractProcessingHandler
         $this->table = $table;
         $this->additionalFields = $additionalFields;
         parent::__construct($level, $bubble);
+
+        if ($skipDatabaseModifications) {
+            $this->mergeDefaultAndAdditionalFields();
+            $this->initialized = true;
+        }
     }
 
     /**
@@ -121,8 +128,7 @@ class MySQLHandler extends AbstractProcessingHandler
             }
         }
 
-        // merge default and additional field to one array
-        $this->defaultfields = array_merge($this->defaultfields, $this->additionalFields);
+        $this->mergeDefaultAndAdditionalFields();
 
         $this->initialized = true;
     }
@@ -219,5 +225,13 @@ class MySQLHandler extends AbstractProcessingHandler
         );
 
         $this->statement->execute($contentArray);
+    }
+
+    /**
+     * Merges default and additional fields into one array
+     */
+    private function mergeDefaultAndAdditionalFields()
+    {
+        $this->defaultfields = array_merge($this->defaultfields, $this->additionalFields);
     }
 }


### PR DESCRIPTION
Currently initialize() method contains various attempts to sync database state with table name and set of fields defined on class initialization (including a rather unintuitive drop of not provided fields, as pointed out in #11 ).

It also requires the database user to have CREATE and ALTER privileges for the table which might be unwanted for security reasons.

Maybe we can allow users to take care of this part of initialization manually at one's own responsibility (CREATE TABLE query is copied to readme so that users who choose to avoind automatic database modifications know which fields they need by default).